### PR TITLE
Update local state from response

### DIFF
--- a/packages/cds-core/src/cds_core/remote.py
+++ b/packages/cds-core/src/cds_core/remote.py
@@ -198,6 +198,7 @@ class BaseAPI:
         global_state: Reactive[BaseAppState],
         local_state: Reactive[BaseStoryState],
     ) -> BaseStoryState | None:
+        student_id = global_state.value.student.id
         if global_state.value.update_db and not self.is_educator:
             story_json = (
                 self.request_session.get(


### PR DESCRIPTION
This PR updates the core remote method to update the local state value (as well as the global state value) when we fetch the story states from the database.

I should note that I haven't tested this yet outside the context of #14.