### PR TITLE
Update stage 6 name

### DIFF
--- a/packages/cds-hubble/src/cds_hubble/routes.py
+++ b/packages/cds-hubble/src/cds_hubble/routes.py
@@ -66,6 +66,6 @@ routes = [
     solara.Route(
         path="prodata",
         component=solara.component(lambda: ProDataPage(**{"app_state": APP_STATE})),
-        label="ProData",
+        label="Professional Data",
     ),
 ]


### PR DESCRIPTION
Fixes #32.

I opted not to rename Stage 5 to "Class Data and Uncertainties" as the issue mentioned that it used to be, as this doesn't fit inside the navigation drawer (see below). If we really want to change that we can maybe explore some dynamic sizing of the stage name text?

<img width="260" height="369" alt="Screenshot 2025-11-26 at 9 17 09 AM" src="https://github.com/user-attachments/assets/9a05be60-a57b-4004-8dea-5b50e2c931bb" />
