### PR TITLE
Let educator decide whether or not to pad Hubble class

### DIFF
--- a/packages/cds-portal/src/cds_portal/pages/manage_classes/__init__.py
+++ b/packages/cds-portal/src/cds_portal/pages/manage_classes/__init__.py
@@ -27,6 +27,7 @@ def CreateClassDialog(on_create_clicked: callable = None):
     stories, set_stories = solara.use_state("")
     expected_size, set_expected_size = solara.use_state(20)
     asynchronous, set_asynchronous = solara.use_state(False)
+    pad, set_pad = solara.use_state(True)
     expected_size_error = solara.use_reactive(False)
 
     with rv.Dialog(
@@ -89,13 +90,23 @@ def CreateClassDialog(on_create_clicked: callable = None):
                     on_value=set_asynchronous,
                 )
 
+                solara.Text("""
+                    Would you like to pad your class's data with data from previous students?
+                    This will allow your students to dive directly into examining data in Stages 4 and 5 without waiting,
+                    but means that they will see data from students other than just their classmates
+                """)
+                solara.Checkbox(
+                    label="Pad class data",
+                    value=pad,
+                    on_value=set_pad,
+                )
+
             rv.Divider()
 
             with rv.CardActions():
 
                 @solara.lab.computed
                 def create_button_disabled():
-                    print(expected_size_error)
                     return expected_size_error.value or (not (text and stories))
 
                 def _add_button_clicked(*args):
@@ -106,6 +117,7 @@ def CreateClassDialog(on_create_clicked: callable = None):
                             "expected_size": expected_size,
                             "asynchronous": asynchronous,
                             "story_name": format_story_name(stories),
+                            "pad": pad,
                         }
                     )
                     set_active(False)

--- a/packages/cds-portal/src/cds_portal/pages/manage_classes/__init__.py
+++ b/packages/cds-portal/src/cds_portal/pages/manage_classes/__init__.py
@@ -24,11 +24,15 @@ def format_story_name(name: str):
 def CreateClassDialog(on_create_clicked: callable = None):
     active, set_active = solara.use_state(False)  #
     text, set_text = solara.use_state("")
-    stories, set_stories = solara.use_state("")
+    stories = solara.use_reactive("")
     expected_size, set_expected_size = solara.use_state(20)
     asynchronous, set_asynchronous = solara.use_state(False)
     pad, set_pad = solara.use_state(True)
     expected_size_error = solara.use_reactive(False)
+
+    @solara.lab.computed
+    def show_pad_option():
+        return stories.value == "Hubble's Law"
 
     with rv.Dialog(
         v_model=active,
@@ -63,9 +67,9 @@ def CreateClassDialog(on_create_clicked: callable = None):
                 )
 
                 rv.Select(
-                    v_model=stories,
+                    v_model=stories.value,
                     outlined=True,
-                    on_v_model=set_stories,
+                    on_v_model=stories.set,
                     class_="pt-2",
                     hide_details="auto",
                     label="Data Story",
@@ -90,16 +94,17 @@ def CreateClassDialog(on_create_clicked: callable = None):
                     on_value=set_asynchronous,
                 )
 
-                solara.Text("""
-                    Would you like to pad your class's data with data from previous students?
-                    This will allow your students to dive directly into examining data in Stages 4 and 5 without waiting,
-                    but means that they will see data from students other than just their classmates
-                """)
-                solara.Checkbox(
-                    label="Pad class data",
-                    value=pad,
-                    on_value=set_pad,
-                )
+                if show_pad_option.value:
+                    solara.Text("""
+                        Would you like to pad your class's data with data from previous students?
+                        This will allow your students to dive directly into examining data in Stages 4 and 5 without waiting,
+                        but means that they will see data from students other than just their classmates
+                    """)
+                    solara.Checkbox(
+                        label="Pad class data",
+                        value=pad,
+                        on_value=set_pad,
+                    )
 
             rv.Divider()
 
@@ -107,16 +112,16 @@ def CreateClassDialog(on_create_clicked: callable = None):
 
                 @solara.lab.computed
                 def create_button_disabled():
-                    return expected_size_error.value or (not (text and stories))
+                    return expected_size_error.value or (not (text and stories.value))
 
                 def _add_button_clicked(*args):
                     on_create_clicked(
                         {
                             "name": f"{text}",
-                            "stories": f"{', '.join(stories)}",
+                            "stories": f"{', '.join(stories.value)}",
                             "expected_size": expected_size,
                             "asynchronous": asynchronous,
-                            "story_name": format_story_name(stories),
+                            "story_name": format_story_name(stories.value),
                             "pad": pad,
                         }
                     )

--- a/packages/cds-portal/src/cds_portal/pages/manage_classes/__init__.py
+++ b/packages/cds-portal/src/cds_portal/pages/manage_classes/__init__.py
@@ -25,7 +25,7 @@ def CreateClassDialog(on_create_clicked: callable = None):
     active, set_active = solara.use_state(False)  #
     text, set_text = solara.use_state("")
     stories = solara.use_reactive("")
-    expected_size, set_expected_size = solara.use_state(20)
+    expected_size = solara.use_reactive(20)
     asynchronous, set_asynchronous = solara.use_state(False)
     pad, set_pad = solara.use_state(True)
     expected_size_error = solara.use_reactive(False)
@@ -33,6 +33,20 @@ def CreateClassDialog(on_create_clicked: callable = None):
     @solara.lab.computed
     def show_pad_option():
         return stories.value == "Hubble's Law"
+
+    def on_expected_size(size: int):
+        if size <= 15:
+            set_pad(True)
+    expected_size.subscribe(on_expected_size)
+
+    @solara.lab.computed
+    def pad_disabled():
+        return expected_size.value < 12
+
+    def on_pad_disabled(disabled: bool):
+        if disabled:
+            set_pad(True)
+    pad_disabled.subscribe(on_pad_disabled)
 
     with rv.Dialog(
         v_model=active,
@@ -80,7 +94,6 @@ def CreateClassDialog(on_create_clicked: callable = None):
                 IntegerInput(
                     label="Expected size",
                     value=expected_size,
-                    on_value=set_expected_size,
                     on_error_change=expected_size_error.set,
                     continuous_update=True,
                     outlined=True,
@@ -104,6 +117,7 @@ def CreateClassDialog(on_create_clicked: callable = None):
                         label="Pad class data",
                         value=pad,
                         on_value=set_pad,
+                        disabled=pad_disabled.value,
                     )
 
             rv.Divider()
@@ -197,6 +211,37 @@ def DeleteClassDialog(disabled: bool, on_delete_clicked: callable = None):
 
 
 @solara.component
+def InfoDialog(title: str, information: str):
+    active, set_active = solara.use_state(False)
+
+    with rv.Dialog(
+        v_model=active,
+        on_v_model=set_active,
+        v_slots=[
+            {
+                "name": "activator",
+                "variable": "x",
+                "children": rv.Btn(
+                    v_on="x.on",
+                    v_bind="x.attrs",
+                    icon=True,
+                    children=[rv.Icon(children=["mdi-information-outline"])],
+                    elevation=0,
+                    color="accent",
+                    class_="ma-0",
+                )
+            }
+        ],
+        max_width=600,
+    ):
+        with rv.Card(outlined=True):
+            rv.CardTitle(children=[title])
+
+            with rv.CardText():
+                solara.Div(information)
+
+
+@solara.component
 def ClassActionsDialog(disabled: bool,
                        class_data: list[dict],
                        on_active_changed: Optional[Callable] = None):
@@ -261,7 +306,7 @@ def ClassActionsDialog(disabled: bool,
                     solara.Text(f"Set whether or not the selected {classes_string} {is_are_string} active")
                 with solara.Row():
                     any_active = any(BASE_API.get_class_active(data["id"], "hubbles_law") for data in class_data)
-                    solara.Switch(label="Set active", value=any_active, on_value=_on_active_switched)
+                    solara.Switch(label="Set active", classes=["mt-0"], value=any_active, on_value=_on_active_switched)
                     rv.Alert(children=[f"This will affect {len(class_data)} {classes_string}"],
                              color="accent",
                              outlined=True,
@@ -270,6 +315,7 @@ def ClassActionsDialog(disabled: bool,
             if "Hubble's Law" in classes_by_story:
 
                 hubble_classes = classes_by_story["Hubble's Law"]
+                hubbles_classes_string = "class" if len(hubble_classes) == 1 else "classes"
 
                 override_statuses = [BASE_API.get_hubble_waiting_room_override(data["id"])["override_status"] for data in hubble_classes]
                 all_overridden = all(override_statuses)
@@ -293,18 +339,59 @@ def ClassActionsDialog(disabled: bool,
                     _update_snackbar(message=message, color=color)
 
                 with rv.Container():
-                    with rv.CardText():
-                        solara.Text("Set the small class override for the selected classes. If a class already has the override set, there will be no effect.")
                     with solara.Row():
                         no_override_count = len(hubble_classes) - sum(override_statuses)
                         no_override_classes = "class" if no_override_count == 1 else "classes"
                         solara.Button(label="Set override",
                                       on_click=_on_override_button_pressed,
                                       disabled=all_overridden)
+                        InfoDialog(
+                            title="Small class override",
+                            information="""
+                                Set the small class override for the selected classes. If a class already has the override set, there will be no effect.
+
+                                If the small class override is set, a student can advance past the stage 4 waiting room without needing data from 12 other students."
+                                """
+                        )
                         rv.Alert(children=[f"This will affect {no_override_count} {no_override_classes}"],
                                  color="accent",
                                  outlined=True,
                                  dense=True)
+
+                def _on_padding_button_pressed(*args):
+                    failures = []
+                    for data in hubble_classes:
+                        class_id = data["id"]
+                        result = BASE_API.pad_class(class_id)
+                        if not result:
+                            failures.append(class_id)
+
+                    color = "error" if failures else "success"
+                    ids_string = ", ".join(str(cid) for cid in failures)
+                    message = f"There was an error padding classes {ids_string}" if failures else "Classes padded succesfully"
+                    _update_snackbar(message=message, color=color)
+
+                padded_classes = [BASE_API.get_merged_students_count(data["id"]) >= 12 for data in hubble_classes]
+                all_padded = all(padded_classes)
+
+                padding_count = len(hubble_classes) - sum(padded_classes)
+                padding_classes = "class" if padding_count == 1 else "classes"
+                with rv.Container():
+                    with solara.Row():
+                        solara.Button(label=f"Pad {hubbles_classes_string}",
+                                      on_click=_on_padding_button_pressed,
+                                      disabled=all_padded)
+                        InfoDialog(
+                            title="Merge students",
+                            information=f"""
+                            Pad the selected classes with 12 students. If a class has already been padded, this will have no effect.
+
+                            Unless the small class override is set, a student needs data from 12 other students to advance past the waiting room at stage 4. Selecting this option will pad the selected {padding_classes} with 12 students so that students can immediately advance past stage 4.
+                            """)
+                        rv.Alert(children=[f"This will affect {padding_count} {padding_classes}"],
+                             color="accent",
+                             outlined=True,
+                             dense=True)
 
                 rv.Spacer()
 
@@ -430,11 +517,11 @@ def Page():
 
             with rv.Row(class_="class_buttons mb-2 mx-0"):
 
-                # ClassActionsDialog(
-                #     disabled = len(selected_rows.value) == 0, 
-                #     class_data = selected_rows.value,
-                #     on_active_changed=lambda *args: retrieve.set(retrieve.value + 1)
-                # )
+                ClassActionsDialog(
+                    disabled = len(selected_rows.value) == 0, 
+                    class_data = selected_rows.value,
+                    on_active_changed=lambda *args: retrieve.set(retrieve.value + 1)
+                )
                 solara.Button(
                     "Educator Preview",
                     text=False,

--- a/packages/cds-portal/src/cds_portal/pages/manage_classes/__init__.py
+++ b/packages/cds-portal/src/cds_portal/pages/manage_classes/__init__.py
@@ -108,17 +108,20 @@ def CreateClassDialog(on_create_clicked: callable = None):
                 )
 
                 if show_pad_option.value:
-                    solara.Text("""
+                    info = """
                         Would you like to pad your class's data with data from previous students?
                         This will allow your students to dive directly into examining data in Stages 4 and 5 without waiting,
                         but means that they will see data from students other than just their classmates
-                    """)
-                    solara.Checkbox(
-                        label="Pad class data",
-                        value=pad,
-                        on_value=set_pad,
-                        disabled=pad_disabled.value,
-                    )
+                    """
+                    with solara.Row():
+                        solara.Checkbox(
+                            label="Pad class data",
+                            value=pad,
+                            on_value=set_pad,
+                            disabled=pad_disabled.value,
+                            style="margin-top: 0;",
+                        )
+                        InfoDialog(title="Pad class data", information=info)
 
             rv.Divider()
 

--- a/packages/cds-portal/src/cds_portal/pages/manage_classes/__init__.py
+++ b/packages/cds-portal/src/cds_portal/pages/manage_classes/__init__.py
@@ -108,11 +108,14 @@ def CreateClassDialog(on_create_clicked: callable = None):
                 )
 
                 if show_pad_option.value:
-                    info = """
-                        Would you like to pad your class's data with data from previous students?
-                        This will allow your students to dive directly into examining data in Stages 4 and 5 without waiting,
-                        but means that they will see data from students other than just their classmates
-                    """
+                    info = [
+                        "Select this option to pad your class with 12 students with completed data.",
+                        """
+                        Students need data from 12 other students to advance through the Stage 4 waiting room.
+                        Selecting this option will allow them to advance into Stage 4 immediately, but they will see
+                        data from students outside of the class.
+                        """
+                    ]
                     with solara.Row():
                         solara.Checkbox(
                             label="Pad class data",
@@ -214,7 +217,7 @@ def DeleteClassDialog(disabled: bool, on_delete_clicked: callable = None):
 
 
 @solara.component
-def InfoDialog(title: str, information: str):
+def InfoDialog(title: str, information: str | list[str]):
     active, set_active = solara.use_state(False)
 
     with rv.Dialog(
@@ -241,7 +244,11 @@ def InfoDialog(title: str, information: str):
             rv.CardTitle(children=[title])
 
             with rv.CardText():
-                solara.Div(information)
+                if isinstance(information, list):
+                    for item in information:
+                        solara.Div(item)
+                else:
+                    solara.Div(information)
 
 
 @solara.component
@@ -350,11 +357,10 @@ def ClassActionsDialog(disabled: bool,
                                       disabled=all_overridden)
                         InfoDialog(
                             title="Small class override",
-                            information="""
-                                Set the small class override for the selected classes. If a class already has the override set, there will be no effect.
-
-                                If the small class override is set, a student can advance past the stage 4 waiting room without needing data from 12 other students."
-                                """
+                            information=[
+                                "Set the small class override for the selected classes. If a class already has the override set, there will be no effect.",
+                                "If the small class override is set, a student can advance past the stage 4 waiting room without needing data from 12 other students."
+                            ],
                         )
                         rv.Alert(children=[f"This will affect {no_override_count} {no_override_classes}"],
                                  color="accent",
@@ -386,11 +392,11 @@ def ClassActionsDialog(disabled: bool,
                                       disabled=all_padded)
                         InfoDialog(
                             title="Merge students",
-                            information=f"""
-                            Pad the selected classes with 12 students. If a class has already been padded, this will have no effect.
-
-                            Unless the small class override is set, a student needs data from 12 other students to advance past the waiting room at stage 4. Selecting this option will pad the selected {padding_classes} with 12 students so that students can immediately advance past stage 4.
-                            """)
+                            information=[
+                                "Pad the selected classes with 12 students. If a class has already been padded, this will have no effect.",
+                                f"Unless the small class override is set, a student needs data from 12 other students to advance past the waiting room at stage 4. Selecting this option will pad the selected {padding_classes} with 12 students so that students can immediately advance past stage 4.",
+                            ]
+                        )
                         rv.Alert(children=[f"This will affect {padding_count} {padding_classes}"],
                              color="accent",
                              outlined=True,

--- a/packages/cds-portal/src/cds_portal/remote.py
+++ b/packages/cds-portal/src/cds_portal/remote.py
@@ -204,6 +204,7 @@ class BaseAPI:
                 "expected_size": info["expected_size"],
                 "asynchronous": info["asynchronous"],
                 "story_name": info["story_name"],
+                "options": { "pad": info["pad"] },
             },
         )
 

--- a/packages/cds-portal/src/cds_portal/remote.py
+++ b/packages/cds-portal/src/cds_portal/remote.py
@@ -273,6 +273,19 @@ class BaseAPI:
         )
         return r.json()["success"]
 
+    def get_merged_students_count(self, class_id: int) -> int:
+        r = self.request_session.get(
+            f"{self.API_URL}/hubbles_law/merge-students/{class_id}"
+        )
+        return len(r.json()["students"])
+
+    def pad_class(self, class_id: int, count=12) -> bool:
+        r = self.request_session.put(
+            f"{self.API_URL}/hubbles_law/merge-students",
+            json={"class_id": class_id, "desired_merge_count": count}
+        )
+        return r.status_code == 200
+
     @staticmethod
     def clear_user(state: Reactive[GlobalState]):
         Ref(state.fields.student.id).set(0)


### PR DESCRIPTION
This PR allows letting an educator choose whether or not to pad their class's data by merging in students using the scheme described in #45. By default this is set to true.

Marking this as a draft for now as it depends on https://github.com/cosmicds/cds-api/pull/245.