### PR TITLE
Send student IDs to server

### DIFF
--- a/packages/cds-hubble/src/cds_hubble/remote.py
+++ b/packages/cds-hubble/src/cds_hubble/remote.py
@@ -339,7 +339,7 @@ class LocalAPI(BaseAPI):
     ) -> list[StudentMeasurement]:
 
         url = (
-            f"{self.api_url}/{local_state.value.story_id}/class-measurements/"
+            f"{self.API_URL}/{local_state.value.story_id}/class-measurements/"
             f"{global_state.value.student.id}/{global_state.value.classroom.class_info['id']}"
             f"?complete_only=true"
         )

--- a/packages/cds-hubble/src/cds_hubble/remote.py
+++ b/packages/cds-hubble/src/cds_hubble/remote.py
@@ -335,12 +335,16 @@ class LocalAPI(BaseAPI):
         self,
         global_state: Reactive[AppState],
         local_state: Reactive[StoryState],
+        student_ids: Optional[List[int]] = None,
     ) -> list[StudentMeasurement]:
+
         url = (
-            f"{self.API_URL}/{local_state.value.story_id}/class-measurements/"
+            f"{self.api_url}/{local_state.value.story_id}/class-measurements/"
             f"{global_state.value.student.id}/{global_state.value.classroom.class_info['id']}"
             f"?complete_only=true"
         )
+        if student_ids:
+            url += f"&student_ids={''.join([str(x) for x in student_ids])}"
         r = self.request_session.get(url)
         measurement_json = r.json()
 

--- a/packages/cds-hubble/src/cds_hubble/stages/p04_explore_data/__init__.py
+++ b/packages/cds-hubble/src/cds_hubble/stages/p04_explore_data/__init__.py
@@ -127,18 +127,14 @@ def Page(app_state: Reactive[AppState]):
 
     def load_class_data():
         logger.info("Loading class data")
-        class_measurements = LOCAL_API.get_class_measurements(app_state, story_state)
         measurements = Ref(story_state.fields.class_measurements)
         student_ids = Ref(story_state.fields.stage_4_class_data_students)
-        if not class_measurements:
-            return []
 
-        if student_ids.value:
-            class_data_points = [
-                m for m in class_measurements if m.student_id in student_ids.value
-            ]
-        else:
-            class_data_points = class_measurements
+        ids = student_ids.value or None
+        class_measurements = LOCAL_API.get_class_measurements(app_state, story_state, ids)
+
+        class_data_points = class_measurements
+        if not student_ids.value:
             ids = [
                 int(id) for id in np.unique([m.student_id for m in class_measurements])
             ]

--- a/packages/cds-hubble/src/cds_hubble/stages/p05_class_results/__init__.py
+++ b/packages/cds-hubble/src/cds_hubble/stages/p05_class_results/__init__.py
@@ -171,14 +171,16 @@ def Page(app_state: Reactive[AppState]):
         if not story_state.value.measurements_loaded:
             LOCAL_API.get_measurements(app_state, story_state)
 
-        class_measurements = LOCAL_API.get_class_measurements(app_state, story_state)
+        student_ids = Ref(story_state.fields.stage_5_class_data_students)
+        ids = student_ids.value or None
+        class_measurements = LOCAL_API.get_class_measurements(app_state, story_state, ids)
+
         # if we are a teacher then our measurements were not loaded with class_measurements and only exist on the front end in local_state.value.measuements
         #  make sure we add these to the class_measurements
         if (not app_state.value.update_db) and len(story_state.value.measurements) > 0:
             class_measurements.extend(m for m in story_state.value.measurements)
 
         measurements = Ref(story_state.fields.class_measurements)
-        student_ids = Ref(story_state.fields.stage_5_class_data_students)
         if class_measurements and not student_ids.value:
             ids = list(np.unique([m.student_id for m in class_measurements]))
             student_ids.set(ids)
@@ -238,9 +240,7 @@ def Page(app_state: Reactive[AppState]):
         class_ids = story_state.value.stage_5_class_data_students
         if (not app_state.value.update_db) and len(story_state.value.measurements) > 0:
             class_ids.append([m.student_id for m in story_state.value.measurements][0])
-        class_data_points = [
-            m for m in story_state.value.class_measurements if m.student_id in class_ids
-        ]
+        class_data_points = story_state.value.class_measurements
         class_data = models_to_glue_data(class_data_points, label="Class Data")
         class_data = app_state.value.add_or_update_data(class_data)
 


### PR DESCRIPTION
Currently, if we already have a list of student IDs for stage 4/5 data, we just ask the server for the class measurements and then filter out measurements that aren't from those students in the app. This PR updates the logic so that we instead send the IDs to the server, which will then only give us those students' measurements and we don't need to filter here. This change will allow users to have a consistent experience once we switch to the "new" system for merging students into classes.

Note: This depends on https://github.com/cosmicds/cds-api/pull/245.